### PR TITLE
Smaller uint64 max data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Int Byte Utils
 
 Utilities for converting (u)integers to and from a slice of bytes; supports the standard io.Writer and io.Reader.
-This is almost the same as varint provided in the standard encoding/binary package with different interface targets.
+This is almost the same as varint provided in the standard encoding/binary package with different interface targets
+and that only up to 64 bits is supported allowing for 9 byte uint max storage rather than 10 bytes.
 
 ## Format
 All byte data is treated as unsigned integers by default, 
@@ -9,6 +10,8 @@ the most significant bit of each byte signifies another byte follows,
 the rest of the bits are in order within each byte, representing the most significant to the least significant bit, 
 however, the bytes are in the reverse order where the least significant bits are in the first byte and the most significant in the last byte.
 This allows for a full uinteger to be stored without explicitly recording the length of the structure.
+However, when the most significant bit of a uint64 is in use, rather than extend for another byte, the most significant bit is used for storage
+allowing for a 9 byte max size as opposed to 10 bytes sacrificing support for 128 bit uints but saving space.
 
 ### EG:
 65537 = [129 128 4] = [~~1~~0000001 ~~1~~0000000 ~~0~~0000100] -> [1 0 4]

--- a/int_byte_reader_writer.go
+++ b/int_byte_reader_writer.go
@@ -7,6 +7,15 @@ import (
 
 const highestBit = uint((math.MaxUint + 1) >> 1)
 
+// LenIntAsBytes gets the length of the data representing the passed value
+func LenIntAsBytes(i int) int {
+	if i < 0 {
+		return LenUintAsBytes(uint(-i) | highestBit)
+	} else {
+		return LenUintAsBytes(uint(i))
+	}
+}
+
 // WriteIntAsBytes writes an integer to an io.Writer supporting negative integers
 // with the sign bit as the first bit of the last byte
 func WriteIntAsBytes(i int, writer io.Writer) (n int, err error) {

--- a/int_byte_reader_writer_reduced.go
+++ b/int_byte_reader_writer_reduced.go
@@ -5,6 +5,18 @@ import (
 	"math"
 )
 
+// LenIntAsBytesReduced gets the length of the data representing the passed value
+func LenIntAsBytesReduced(i int) int {
+	var ui uint
+	if i < 0 {
+		ui = uint(-i)
+		return LenUintAsBytes(ui<<1 | 1)
+	} else {
+		ui = uint(i)
+		return LenUintAsBytes(ui << 1)
+	}
+}
+
 // WriteIntAsBytesReduced writes an integer to an io.Writer supporting negative integers
 // with the sign bit as the last bit of the first byte
 func WriteIntAsBytesReduced(i int, writer io.Writer) (n int, err error) {

--- a/int_byte_reader_writer_reduced_test.go
+++ b/int_byte_reader_writer_reduced_test.go
@@ -14,6 +14,8 @@ func testIntReduced(t *testing.T, v int) {
 	assert.NoError(t, err)
 	t.Log(n)
 	t.Log(buff.Bytes())
+	t.Log(LenIntAsBytesReduced(v))
+	assert.Equal(t, LenIntAsBytesReduced(v), buff.Len())
 	var val int
 	n, err, val = ReadIntFromBytesReduced(buff)
 	assert.NoError(t, err)

--- a/int_byte_reader_writer_test.go
+++ b/int_byte_reader_writer_test.go
@@ -14,6 +14,8 @@ func testInt(t *testing.T, v int) {
 	assert.NoError(t, err)
 	t.Log(n)
 	t.Log(buff.Bytes())
+	t.Log(LenIntAsBytes(v))
+	assert.Equal(t, LenIntAsBytes(v), buff.Len())
 	var val int
 	n, err, val = ReadIntFromBytes(buff)
 	assert.NoError(t, err)

--- a/uint_byte_reader_writer.go
+++ b/uint_byte_reader_writer.go
@@ -12,6 +12,24 @@ const bits7 = 127
 const bit8 = 128
 const platformBits = 32 << (^uint(0) >> 63) // from go math package
 
+// LenUintAsBytes gets the length of the data representing the passed value
+func LenUintAsBytes(i uint) (n int) {
+	if i == 0 {
+		return 1
+	}
+	n = 0
+	currentI := i
+	for currentI > 0 {
+		if n == 8 { // (8+1)*8 = 56, last byte for uint64 uses most significant as storage rather than an extension signifier
+			currentI = 0
+		} else {
+			currentI = currentI >> 7
+		}
+		n++
+	}
+	return
+}
+
 // WriteUintAsBytes writes an integer to an io.Writer
 func WriteUintAsBytes(i uint, writer io.Writer) (n int, err error) {
 	if i == 0 {

--- a/uint_byte_reader_writer.go
+++ b/uint_byte_reader_writer.go
@@ -3,7 +3,6 @@ package int_byte_utils
 import (
 	"errors"
 	"io"
-	"math"
 )
 
 // OverflowError the read value has overflowed the container.
@@ -22,10 +21,16 @@ func WriteUintAsBytes(i uint, writer io.Writer) (n int, err error) {
 	n = 0
 	currentI := i
 	for currentI > 0 {
-		var bt = byte(currentI & bits7)
-		currentI = currentI >> 7
-		if currentI > 0 {
-			bt |= bit8
+		var bt byte
+		if n == 8 { // (8+1)*8 = 56, last byte for uint64 uses most significant as storage rather than an extension signifier
+			bt = byte(currentI)
+			currentI = 0
+		} else {
+			bt = byte(currentI & bits7)
+			currentI = currentI >> 7
+			if currentI > 0 {
+				bt |= bit8
+			}
 		}
 		cbw, err := writer.Write([]byte{bt})
 		n += cbw
@@ -48,10 +53,8 @@ func ReadUintFromBytes(r io.Reader) (n int, err error, val uint) {
 		if err != nil {
 			return n, err, val
 		}
-		if cBuff[0] < bit8 {
-			if (uint(cBuff[0])<<cBitSize)>>cBitSize < uint(cBuff[0]) {
-				return n, OverflowError, math.MaxUint
-			}
+		// Allow for storing a 64 bit uint within 9 bytes by sacrificing the use of the extender bit and limiting support to 64 bits
+		if cBuff[0] < bit8 || cBitSize >= 56 {
 			return n, nil, val | uint(uint(cBuff[0])<<cBitSize)
 		}
 		val |= uint(cBuff[0]&bits7) << cBitSize

--- a/uint_byte_reader_writer_test.go
+++ b/uint_byte_reader_writer_test.go
@@ -54,10 +54,9 @@ func testUintReadOverread(t *testing.T) {
 	t.Log(n)
 	t.Log(err)
 	t.Log(val)
-	assert.Error(t, err)
-	assert.Equal(t, OverflowError, err)
-	assert.Equal(t, uint(0), val)
-	assert.Equal(t, 10, n)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(math.MaxInt)+1, val)
+	assert.Equal(t, 9, n)
 }
 
 func testUintReadOverflow(t *testing.T) {
@@ -67,10 +66,9 @@ func testUintReadOverflow(t *testing.T) {
 	t.Log(n)
 	t.Log(err)
 	t.Log(val)
-	assert.Error(t, err)
-	assert.Equal(t, OverflowError, err)
-	assert.Equal(t, uint(math.MaxUint), val)
-	assert.Equal(t, 10, n)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(math.MaxInt)+1, val)
+	assert.Equal(t, 9, n)
 }
 
 func TestUint(t *testing.T) {

--- a/uint_byte_reader_writer_test.go
+++ b/uint_byte_reader_writer_test.go
@@ -14,6 +14,8 @@ func testUint(t *testing.T, v uint) {
 	assert.NoError(t, err)
 	t.Log(n)
 	t.Log(buff.Bytes())
+	t.Log(LenUintAsBytes(v))
+	assert.Equal(t, LenUintAsBytes(v), buff.Len())
 	var val uint
 	n, err, val = ReadUintFromBytes(buff)
 	assert.NoError(t, err)


### PR DESCRIPTION
Allow for the most significant bit of a uint64 to be stored where the 'another byte follows' most significant bit is used on the last byte of the written series (So the 9th byte allowing for data savings, otherwise it would waste sending another byte for just a single bit).

This removes support for uint128 and above as it assumes uint maxes out at uint64.

This is therefore better than go std varint